### PR TITLE
bug: prevent submitOn prop from throwing exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,143 +1,217 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+  value: true,
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+var _extends =
+  Object.assign ||
+  function (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+  };
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _createClass = (function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+  return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+})();
 
-var _react = require('react');
+var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactDom = require('react-dom');
+var _reactDom = require("react-dom");
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _classCallCheck(instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+}
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+function _possibleConstructorReturn(self, call) {
+  if (!self) {
+    throw new ReferenceError(
+      "this hasn't been initialised - super() hasn't been called"
+    );
+  }
+  return call && (typeof call === "object" || typeof call === "function")
+    ? call
+    : self;
+}
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) {
+  if (typeof superClass !== "function" && superClass !== null) {
+    throw new TypeError(
+      "Super expression must either be null or a function, not " +
+        typeof superClass
+    );
+  }
+  subClass.prototype = Object.create(superClass && superClass.prototype, {
+    constructor: {
+      value: subClass,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+  });
+  if (superClass)
+    Object.setPrototypeOf
+      ? Object.setPrototypeOf(subClass, superClass)
+      : (subClass.__proto__ = superClass);
+}
 
 var globalId = 0;
 
-var HubspotForm = function (_React$Component) {
-	_inherits(HubspotForm, _React$Component);
+var HubspotForm = (function (_React$Component) {
+  _inherits(HubspotForm, _React$Component);
 
-	function HubspotForm(props) {
-		_classCallCheck(this, HubspotForm);
+  function HubspotForm(props) {
+    _classCallCheck(this, HubspotForm);
 
-		var _this = _possibleConstructorReturn(this, (HubspotForm.__proto__ || Object.getPrototypeOf(HubspotForm)).call(this, props));
+    var _this = _possibleConstructorReturn(
+      this,
+      (HubspotForm.__proto__ || Object.getPrototypeOf(HubspotForm)).call(
+        this,
+        props
+      )
+    );
 
-		_this.state = {
-			loaded: false
-		};
-		_this.id = globalId++;
-		_this.createForm = _this.createForm.bind(_this);
-		_this.findFormElement = _this.findFormElement.bind(_this);
-		return _this;
-	}
+    _this.state = {
+      loaded: false,
+    };
+    _this.id = globalId++;
+    _this.createForm = _this.createForm.bind(_this);
+    _this.findFormElement = _this.findFormElement.bind(_this);
+    return _this;
+  }
 
-	_createClass(HubspotForm, [{
-		key: 'createForm',
-		value: function createForm() {
-			var _this2 = this;
+  _createClass(HubspotForm, [
+    {
+      key: "createForm",
+      value: function createForm() {
+        var _this2 = this;
 
-			if (window.hbspt) {
-				// protect against component unmounting before window.hbspt is available
-				if (this.el === null) {
-					return;
-				}
-				var props = _extends({}, this.props);
-				delete props.loading;
-				delete props.onSubmit;
-				delete props.onReady;
-				var options = _extends({}, props, {
-					target: '#' + this.el.getAttribute('id'),
-					onFormSubmit: function onFormSubmit($form) {
-						// ref: https://developers.hubspot.com/docs/methods/forms/advanced_form_options
-						var formData = $form.serializeArray();
-						_this2.props.onSubmit(formData);
-					}
-				});
-				window.hbspt.forms.create(options);
-				return true;
-			} else {
-				setTimeout(this.createForm, 1);
-			}
-		}
-	}, {
-		key: 'loadScript',
-		value: function loadScript() {
-			var _this3 = this;
-			var script = document.createElement('script');
-			script.defer = true;
-			script.onload = function () {
-				_this3.createForm();
-				_this3.findFormElement();
-			};
-			script.src = '//js.hsforms.net/forms/v2.js';
-			document.head.appendChild(script);
-		}
-	}, {
-		key: 'findFormElement',
-		value: function findFormElement() {
-			// protect against component unmounting before form is added
-			if (this.el === null) {
-				return;
-			}
-			var form = this.el.querySelector('iframe');
-			if (form) {
-				this.setState({ loaded: true });
-				if (this.props.onReady) {
-					this.props.onReady(form);
-				}
-			} else {
-				setTimeout(this.findFormElement, 1);
-			}
-		}
-	}, {
-		key: 'componentDidMount',
-		value: function componentDidMount() {
-			if (!window.hbspt && !this.props.noScript) {
-				this.loadScript();
-			} else {
-				this.createForm();
-				this.findFormElement();
-			}
-		}
-	}, {
-		key: 'componentWillUnmount',
-		value: function componentWillUnmount() {}
-	}, {
-		key: 'render',
-		value: function render() {
-			var _this4 = this;
+        if (window.hbspt) {
+          // protect against component unmounting before window.hbspt is available
+          if (this.el === null) {
+            return;
+          }
+          var props = _extends({}, this.props);
+          delete props.loading;
+          delete props.onSubmit;
+          delete props.onReady;
+          var options = _extends({}, props, {
+            target: "#" + this.el.getAttribute("id"),
+            onFormSubmit: function onFormSubmit($form) {
+              // ref: https://developers.hubspot.com/docs/methods/forms/advanced_form_options
+              var formData = $form.serializeArray();
+              _this2.props.onSubmit(formData);
+            },
+          });
+          window.hbspt.forms.create(options);
+          return true;
+        } else {
+          setTimeout(this.createForm, 1);
+        }
+      },
+    },
+    {
+      key: "loadScript",
+      value: function loadScript() {
+        var _this3 = this;
+        var script = document.createElement("script");
+        script.defer = true;
+        script.onload = function () {
+          _this3.createForm();
+          _this3.findFormElement();
+        };
+        script.src = "//js.hsforms.net/forms/v2.js";
+        document.head.appendChild(script);
+      },
+    },
+    {
+      key: "findFormElement",
+      value: function findFormElement() {
+        // protect against component unmounting before form is added
+        if (this.el === null) {
+          return;
+        }
+        var form = this.el.querySelector("iframe");
+        if (form) {
+          this.setState({ loaded: true });
+          if (this.props.onReady) {
+            this.props.onReady(form);
+          }
+        } else {
+          setTimeout(this.findFormElement, 1);
+        }
+      },
+    },
+    {
+      key: "componentDidMount",
+      value: function componentDidMount() {
+        if (!window.hbspt && !this.props.noScript) {
+          this.loadScript();
+        } else {
+          this.createForm();
+          this.findFormElement();
+        }
+      },
+    },
+    {
+      key: "componentWillUnmount",
+      value: function componentWillUnmount() {},
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this4 = this;
 
-			return _react2.default.createElement(
-				'div',
-				null,
-				_react2.default.createElement('div', {
-					ref: function ref(el) {
-						return _this4.el = el;
-					},
-					id: 'reactHubspotForm' + this.id,
-					style: { display: this.state.loaded ? 'block' : 'none' }
-				}),
-				!this.state.loaded && this.props.loading
-			);
-		}
-	}]);
+        return _react2.default.createElement(
+          "div",
+          null,
+          _react2.default.createElement("div", {
+            ref: function ref(el) {
+              return (_this4.el = el);
+            },
+            id: "reactHubspotForm" + this.id,
+            style: { display: this.state.loaded ? "block" : "none" },
+          }),
+          !this.state.loaded && this.props.loading
+        );
+      },
+    },
+  ]);
 
-	return HubspotForm;
-}(_react2.default.Component);
+  return HubspotForm;
+})(_react2.default.Component);
 
 exports.default = HubspotForm;
-module.exports = exports['default'];
+module.exports = exports["default"];
 
 //# sourceMappingURL=index.js.map

--- a/index.js
+++ b/index.js
@@ -121,20 +121,24 @@ var HubspotForm = (function (_React$Component) {
           if (this.el === null) {
             return;
           }
-          var props = _extends({}, this.props);
+          let props = _extends({}, this.props);
           delete props.loading;
           delete props.onSubmit;
           delete props.onReady;
-          var options = _extends({}, props, {
+
+          let options = _extends({}, props, {
             // ref: https://developers.hubspot.com/docs/methods/forms/advanced_form_options
             target: "#" + this.el.getAttribute("id"),
-            onFormSubmit: function onFormSubmit(form) {
+          });
+
+          if (_this2.props.hasOwnProperty("onSubmit")) {
+            options["onFormSubmit"] = (form) => {
               const formData = new FormData(form);
               const formValues = Object.fromEntries(formData.entries());
-
               _this2.props.onSubmit(formValues);
-            },
-          });
+            };
+          }
+
           window.hbspt.forms.create(options);
           return true;
         } else {

--- a/index.js
+++ b/index.js
@@ -126,11 +126,13 @@ var HubspotForm = (function (_React$Component) {
           delete props.onSubmit;
           delete props.onReady;
           var options = _extends({}, props, {
+            // ref: https://developers.hubspot.com/docs/methods/forms/advanced_form_options
             target: "#" + this.el.getAttribute("id"),
-            onFormSubmit: function onFormSubmit($form) {
-              // ref: https://developers.hubspot.com/docs/methods/forms/advanced_form_options
-              var formData = $form.serializeArray();
-              _this2.props.onSubmit(formData);
+            onFormSubmit: function onFormSubmit(form) {
+              const formData = new FormData(form);
+              const formValues = Object.fromEntries(formData.entries());
+
+              _this2.props.onSubmit(formValues);
             },
           });
           window.hbspt.forms.create(options);


### PR DESCRIPTION
When integrating the HubspotForm component into a new page on`getambassador.io` the following error was thrown when submitting the form:

![Screenshot 2023-07-11 at 3 52 53 PM](https://github.com/datawire/datawire-react-hubspot-form/assets/8103374/d362d4d4-4d19-4731-9214-de80ab57a561)


This happens because we do not embed jquery into the getambassador.io site and it is trying to use jquery functions that are added to the html `FormElement` https://api.jquery.com/serializearray/ but don't exist, thus throwing the exception. I also noticed during testing that if I didn't provide an `onSubmit` prop that it would throw an exception as well.

This fixes the component by doing the following:

1. Only set HubSpot `option.OnFormSubmit` when `onSubmit` prop is provided
  - https://legacydocs.hubspot.com/docs/methods/forms/advanced_form_options
2. Leverage  the `FormData` standard browser api for extracting form values and passing them to `onSubmit` handler
  - https://caniuse.com/mdn-api_formdata

I think the proposed is a simple approach to avoid adding the overhead of jquery for a simple embedded form. See further analysis below. 

## datawire/getambassador.io
I reviewed usage of this component and the onSubmit prop and it looks passing the form data as an object (key:value) will not break any current usage of the component _(because all usage is just sending empty func)_.

At this time we do not add jquery at all:
https://github.com/search?q=repo%3Adatawire%2Fgetambassador.io%20jquery&type=code

I have also added the following PR to getambassador.io to ensure we are pinned before this lands.
https://github.com/datawire/getambassador.io/pull/2505

## datawire/saas_app

It looks like this is using a published package from NPM. Reveiwing that package and it makes the same assumption that jquery is loaded:
https://github.com/escaladesports/react-hubspot-form/blob/master/src/index.js

It looks like we do have a function where we embed jquery if hubspot is around:
https://github.com/datawire/saas_app/blob/4b3268e0f59735aebffd8cf10071596161172681/ui/src/pages/welcomePage/utils.ts#L71

## datawire organization

It appears this library is currently only used in `getambassador.io` for our Github Org.
https://github.com/search?q=org%3Adatawire+datawire-react-hubspot-form&type=code

